### PR TITLE
Update .NET version to 9.0.x in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
       run: dotnet build --no-restore --configuration Release
 
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --configuration Release


### PR DESCRIPTION
Bump the .NET version from 8.0.x to 9.0.x in the GitHub Actions CI workflow to use the latest .NET features and improvements.