### PR TITLE
Add Kafka event publishing for user auth events

### DIFF
--- a/SkillLearning.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/SkillLearning.Api/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,10 @@ namespace SkillLearning.Infrastructure.Extensions
             services.AddValidatorsFromAssembly(typeof(RegisterUserCommand).Assembly);
             services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+            services.AddSingleton<IEventPublisher, KafkaProducerService>();
+
             services.AddScoped<IUserRepository, UserRepository>();
             services.AddScoped<IAuthService, AuthService>();
 
@@ -52,7 +56,7 @@ namespace SkillLearning.Infrastructure.Extensions
                         ValidateAudience = true,
                         ValidateLifetime = true,
                         ValidateIssuerSigningKey = true,
-                        ValidIssuer = jwt.Issuer,
+                        ValidIssuer = jwt!.Issuer,
                         ValidAudience = jwt.Audience,
                         IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Key))
                     };

--- a/SkillLearning.Api/SkillLearning.Api.csproj
+++ b/SkillLearning.Api/SkillLearning.Api.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />

--- a/SkillLearning.Application/Common/Interfaces/IEventPublisher.cs
+++ b/SkillLearning.Application/Common/Interfaces/IEventPublisher.cs
@@ -1,0 +1,7 @@
+﻿namespace SkillLearning.Application.Common.Interfaces
+{
+    public interface IEventPublisher
+    {
+        Task PublishAsync<TEvent>(TEvent @event, string? topic = null);
+    }
+}

--- a/SkillLearning.Application/Features/Auth/Commands/LoginUserCommandHandler.cs
+++ b/SkillLearning.Application/Features/Auth/Commands/LoginUserCommandHandler.cs
@@ -1,8 +1,10 @@
 ﻿using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using SkillLearning.Application.Common.Configuration;
 using SkillLearning.Application.Common.Interfaces;
 using SkillLearning.Application.Common.Models;
+using SkillLearning.Domain.Events;
 
 namespace SkillLearning.Application.Features.Auth.Commands
 {
@@ -11,12 +13,21 @@ namespace SkillLearning.Application.Features.Auth.Commands
         private readonly IUserRepository _userRepository;
         private readonly IAuthService _authService;
         private readonly JwtSettings _jwtSettings;
+        private readonly IEventPublisher _eventPublisher;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public LoginUserCommandHandler(IUserRepository userRepository, IAuthService authService, IOptions<JwtSettings> jwtSettingsOptions)
+        public LoginUserCommandHandler(
+            IUserRepository userRepository,
+            IAuthService authService,
+            IOptions<JwtSettings> jwtSettingsOptions,
+            IEventPublisher eventPublisher,
+            IHttpContextAccessor httpContextAccessor)
         {
             _userRepository = userRepository;
             _authService = authService;
             _jwtSettings = jwtSettingsOptions.Value;
+            _eventPublisher = eventPublisher;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task<AuthResultDto?> Handle(LoginUserCommand request, CancellationToken cancellationToken)
@@ -30,6 +41,20 @@ namespace SkillLearning.Application.Features.Auth.Commands
 
             var claims = await _authService.GetUserClaims(user);
             var token = _authService.GenerateJwtToken(claims, _jwtSettings.Issuer);
+            var ipAddress = _httpContextAccessor.HttpContext?.Connection?.RemoteIpAddress?.ToString() ?? "Unknown";
+            var userAgent = _httpContextAccessor.HttpContext?.Request?.Headers["User-Agent"].ToString() ?? "Unknown";
+
+            var userLoginEvent = new UserLoginEvent
+            {
+                UserId = user.Id,
+                Username = user.Username,
+                Email = user.Email,
+                Timestamp = DateTime.UtcNow,
+                IpAddress = ipAddress,
+                UserAgent = userAgent
+            };
+
+            await _eventPublisher.PublishAsync(userLoginEvent);
 
             return new AuthResultDto
             {

--- a/SkillLearning.Application/Features/Auth/Commands/RegisterUserCommandHandler.cs
+++ b/SkillLearning.Application/Features/Auth/Commands/RegisterUserCommandHandler.cs
@@ -2,16 +2,21 @@
 using SkillLearning.Application.Common.Interfaces;
 using SkillLearning.Domain.Entities;
 using SkillLearning.Domain.Enums;
+using SkillLearning.Domain.Events;
 
 namespace SkillLearning.Application.Features.Auth.Commands
 {
     public class RegisterUserCommandHandler : IRequestHandler<RegisterUserCommand, bool>
     {
         private readonly IUserRepository _userRepository;
+        private readonly IEventPublisher _eventPublisher;
 
-        public RegisterUserCommandHandler(IUserRepository userRepository)
+        public RegisterUserCommandHandler(
+            IUserRepository userRepository,
+            IEventPublisher eventPublisher)
         {
             _userRepository = userRepository;
+            _eventPublisher = eventPublisher;
         }
 
         public async Task<bool> Handle(RegisterUserCommand request, CancellationToken cancellationToken)
@@ -33,6 +38,15 @@ namespace SkillLearning.Application.Features.Auth.Commands
             };
 
             await _userRepository.AddUserAsync(user);
+
+            var userRegisteredEvent = new UserRegisteredEvent(
+                user.Id,
+                user.Username,
+                user.Email
+            );
+
+            await _eventPublisher.PublishAsync(userRegisteredEvent);
+
             return true;
         }
     }

--- a/SkillLearning.Application/SkillLearning.Application.csproj
+++ b/SkillLearning.Application/SkillLearning.Application.csproj
@@ -7,8 +7,6 @@
   <ItemGroup>
     <Folder Include="Commands\" />
     <Folder Include="Features\Users\Queries\" />
-    <Folder Include="UseCases\Auth\Login\" />
-    <Folder Include="UseCases\Auth\Register\" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,6 +15,7 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
     <PackageReference Include="MediatR" Version="12.5.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
   </ItemGroup>
 

--- a/SkillLearning.Domain/Events/UserLoginEvent.cs
+++ b/SkillLearning.Domain/Events/UserLoginEvent.cs
@@ -1,0 +1,12 @@
+﻿namespace SkillLearning.Domain.Events
+{
+    public class UserLoginEvent
+    {
+        public Guid UserId { get; set; }
+        public string Username { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+        public string IpAddress { get; set; } = string.Empty;
+        public string UserAgent { get; set; } = string.Empty;
+    }
+}

--- a/SkillLearning.Domain/Events/UserRegisteredEvent.cs
+++ b/SkillLearning.Domain/Events/UserRegisteredEvent.cs
@@ -1,0 +1,18 @@
+﻿namespace SkillLearning.Domain.Events
+{
+    public class UserRegisteredEvent
+    {
+        public Guid UserId { get; set; }
+        public string Username { get; set; }
+        public string Email { get; set; }
+        public DateTime RegisteredAt { get; set; }
+
+        public UserRegisteredEvent(Guid userId, string username, string email)
+        {
+            UserId = userId;
+            Username = username;
+            Email = email;
+            RegisteredAt = DateTime.UtcNow;
+        }
+    }
+}

--- a/SkillLearning.Infrastructure/Persistence/Migrations/20250628010345_InitialCreate.Designer.cs
+++ b/SkillLearning.Infrastructure/Persistence/Migrations/20250628010345_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using SkillLearning.Infrastructure.Persistence;
 namespace SkillLearning.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250624234649_InitialCreate")]
+    [Migration("20250628010345_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -45,8 +45,7 @@ namespace SkillLearning.Infrastructure.Persistence.Migrations
 
                     b.Property<string>("Role")
                         .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Username")
                         .IsRequired()

--- a/SkillLearning.Infrastructure/Persistence/Migrations/20250628010345_InitialCreate.cs
+++ b/SkillLearning.Infrastructure/Persistence/Migrations/20250628010345_InitialCreate.cs
@@ -18,7 +18,7 @@ namespace SkillLearning.Infrastructure.Persistence.Migrations
                     Username = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     Email = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     PasswordHash = table.Column<string>(type: "text", nullable: false),
-                    Role = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Role = table.Column<string>(type: "text", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>

--- a/SkillLearning.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/SkillLearning.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -42,8 +42,7 @@ namespace SkillLearning.Infrastructure.Persistence.Migrations
 
                     b.Property<string>("Role")
                         .IsRequired()
-                        .HasMaxLength(20)
-                        .HasColumnType("character varying(20)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Username")
                         .IsRequired()

--- a/SkillLearning.Infrastructure/Services/AuthService.cs
+++ b/SkillLearning.Infrastructure/Services/AuthService.cs
@@ -48,7 +48,7 @@ namespace SkillLearning.Infrastructure.Services
                 new Claim(ClaimTypes.Role, user.Role.ToString())
             };
 
-            return claims;
+            return await Task.FromResult(claims);
         }
     }
 }

--- a/SkillLearning.Infrastructure/Services/KafkaProducerService.cs
+++ b/SkillLearning.Infrastructure/Services/KafkaProducerService.cs
@@ -1,0 +1,72 @@
+﻿using Confluent.Kafka;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SkillLearning.Application.Common.Configuration;
+using SkillLearning.Application.Common.Interfaces;
+using System.Text.Json;
+
+namespace SkillLearning.Infrastructure.Services
+{
+    public class KafkaProducerService : IEventPublisher
+    {
+        private readonly IProducer<Null, string> _producer;
+        private readonly KafkaSettings _kafkaSettings;
+        private readonly ILogger<KafkaProducerService> _logger;
+
+        public KafkaProducerService(IOptions<KafkaSettings> kafkaSettings, ILogger<KafkaProducerService> logger)
+        {
+            _kafkaSettings = kafkaSettings.Value;
+            _logger = logger;
+
+            var config = new ProducerConfig
+            {
+                BootstrapServers = _kafkaSettings.BootstrapServers
+            };
+
+            _producer = new ProducerBuilder<Null, string>(config)
+                .SetErrorHandler((_, e) => _logger.LogError($"Kafka Producer Error: {e.Reason}"))
+                .SetLogHandler((_, logMessage) => _logger.LogInformation($"Kafka Log: {logMessage.Message}"))
+                .Build();
+        }
+
+        public async Task PublishAsync<TEvent>(TEvent @event, string? topic = null)
+        {
+            var eventTypeName = typeof(TEvent).Name;
+            var defaultTopic = char.ToLowerInvariant(eventTypeName[0]) + eventTypeName.Substring(1);
+
+            var targetTopic = topic ?? defaultTopic;
+
+            var messageValue = JsonSerializer.Serialize(@event, new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
+
+            _logger.LogInformation($"Publishing event to Kafka topic '{targetTopic}': {messageValue}");
+
+            try
+            {
+                var message = new Message<Null, string> { Value = messageValue };
+
+                var deliveryResult = await _producer.ProduceAsync(targetTopic, message);
+
+                _logger.LogInformation($"Event delivered to Kafka topic '{deliveryResult.Topic}', Partition: {deliveryResult.Partition.Value}, Offset: {deliveryResult.Offset.Value}");
+            }
+            catch (ProduceException<Null, string> e)
+            {
+                _logger.LogError(e, $"Failed to deliver message to Kafka topic '{targetTopic}': {e.Error.Reason}");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, $"An unexpected error occurred while publishing to Kafka topic '{targetTopic}'.");
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            _producer.Flush(TimeSpan.FromSeconds(10));
+            _producer.Dispose();
+        }
+    }
+}

--- a/SkillLearning.Infrastructure/SkillLearning.Infrastructure.csproj
+++ b/SkillLearning.Infrastructure/SkillLearning.Infrastructure.csproj
@@ -1,16 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <Folder Include="Persistence\Migrations\" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="BCrypt.Net-Core" Version="1.6.0" />
+    <PackageReference Include="Confluent.Kafka" Version="2.10.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,10 @@ services:
       - redis
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:7.5.0
+    image: confluentinc/cp-zookeeper:latest
     container_name: zookeeper
+    ports:
+      - "2181:2181"
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
@@ -72,28 +74,34 @@ services:
       - skilllearning-net
 
   kafka:
-    image: confluentinc/cp-kafka:7.5.0
+    image: confluentinc/cp-kafka:7.0.1
     container_name: kafka
-    ports:
-      - "9092:9092"
     depends_on:
       - zookeeper
+    ports:
+      - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
     networks:
       - skilllearning-net
 
   kafka-ui:
-    image: provectuslabs/kafka-ui
+    image: provectuslabs/kafka-ui:latest
     container_name: kafka-ui
+    depends_on:
+      - kafka
     ports:
-      - "8085:8080"
+      - "8080:8080"
     environment:
-      KAFKA_CLUSTERS_0_NAME: skilllearning-cluster
-      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+      KAFKA_CLUSTERS_0_NAME: local-kafka
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
     networks:
       - skilllearning-net
 


### PR DESCRIPTION
Introduced IEventPublisher interface and KafkaProducerService for publishing domain events to Kafka. User login and registration handlers now publish UserLoginEvent and UserRegisteredEvent, respectively. Updated dependency injection and project references to support Kafka integration. Adjusted database migration for user role column and updated docker-compose to include Kafka and Kafka UI services.