### PR TITLE
Add pull-requests write permission to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
Updated the GitHub Actions CI workflow to grant write permissions for pull-requests. This change is likely required for steps that need to interact with pull requests, such as posting comments or updating statuses.