### PR TITLE
Fix nullability warning in test mock setup

### DIFF
--- a/SkillLearning.Tests/UnitTests/LoginUserCommandHandlerTests.cs
+++ b/SkillLearning.Tests/UnitTests/LoginUserCommandHandlerTests.cs
@@ -61,7 +61,7 @@ namespace SkillLearning.Tests.UnitTests
             _authServiceMock.Setup(s => s.GetUserClaims(userDto)).ReturnsAsync(new List<Claim>());
             _authServiceMock.Setup(s => s.GenerateJwtToken(It.IsAny<IEnumerable<Claim>>(), It.IsAny<string>())).Returns("token");
 
-            _httpContextAccessorMock.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+            _httpContextAccessorMock.Setup(a => a.HttpContext).Returns((HttpContext?)null!);
 
             UserLoginEvent? capturedEvent = null;
             _eventPublisherMock


### PR DESCRIPTION
Updated the mock setup for HttpContext to use null-forgiving operator, resolving a potential nullability warning in LoginUserCommandHandlerTests.